### PR TITLE
Fixes #3: removed space before period

### DIFF
--- a/content/modules.go
+++ b/content/modules.go
@@ -198,7 +198,7 @@ var modules = []module{
 			"Python & Jupyter exercises and troubleshooting",
 			"",
 		},
-		ProjectAssignment:     `Choose a project and complete a literature review .`,
+		ProjectAssignment:     `Choose a project and complete a literature review.`,
 		ProjectAssignmentDays: 17,
 	},
 	{


### PR DESCRIPTION
Very small syntax/grammar fix; a space before a period was removed.